### PR TITLE
Removes IO dependency from parsing and type checking

### DIFF
--- a/src/Chap2/Lexer.hs
+++ b/src/Chap2/Lexer.hs
@@ -69,13 +69,7 @@ runMyParserT m s = runParserT m "" s
 runMyParserT' :: (ParserContext IO => Parser IO a)
               -> String
               -> IO (Either ParseErr a)
-runMyParserT' m s = runParserT m' "" s
- where
-  refM = RefM { newRef = newIORef, readRef = readIORef, writeRef = writeIORef }
-  m' = do
-    symbolM <- liftIO $ mkSymbolM <$> mkSymbolRef <*> mkSymbolTable
-    tempRef <- liftIO $ mkTempRef refM
-    let { ?symbolM = symbolM; ?refM = refM; ?tempRef = tempRef } in m
+runMyParserT' m s = contextDataIO >>= \d -> withContextData d $ runMyParserT m s
 
 sc :: Parser m ()
 sc = L.space (space1 <|> void tab) empty blockCmnt

--- a/src/Chap2/Lexer.hs
+++ b/src/Chap2/Lexer.hs
@@ -28,9 +28,9 @@ data ParserContextData m = ParserContextData
   , tempRef :: TempRef (Ref m)
   }
 
-contextDataIO :: IO (ParserContextData IO)
-contextDataIO = do
-  symbolM <- mkSymbolM refM <$> symbolTableMIO <*> mkSymbolRef refM
+mkContextData :: IO (ParserContextData IO)
+mkContextData = do
+  symbolM <- mkSymbolM refM <$> mkSymbolTableM <*> mkSymbolRef refM
   tempRef <- mkTempRef refM
   return $ ParserContextData symbolM refM tempRef
  where
@@ -49,7 +49,7 @@ runMyParserT m s = runParserT m "" s
 runMyParserT' :: (ParserContext IO => Parser IO a)
               -> String
               -> IO (Either ParseErr a)
-runMyParserT' m s = contextDataIO >>= \d -> withContextData d $ runMyParserT m s
+runMyParserT' m s = mkContextData >>= \d -> withContextData d $ runMyParserT m s
 
 sc :: Parser m ()
 sc = L.space (space1 <|> void tab) empty blockCmnt

--- a/src/Chap2/Lexer.hs
+++ b/src/Chap2/Lexer.hs
@@ -1,54 +1,100 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
 module Chap2.Lexer where
 
 import Control.Monad (void)
 import Control.Monad.Reader
+import Chap3.AST
 import Chap5.Symbol
 import Chap6.Temp
-import Data.Maybe (fromJust)
 import Data.Char (chr, ord)
+import Data.Functor.Classes (Eq1 (liftEq))
+import Data.Maybe (fromJust)
 import Data.Void
 import Text.Megaparsec
 import Text.Megaparsec.Char
+import Unsafe.Coerce (unsafeCoerce)
 
+import qualified Data.IORef as IORef
 import qualified Text.Megaparsec.Char.Lexer as L
 
-data Config = Config
-  { _symRef   :: SymbolRef
-  , _symTable :: SymbolTable
-  , _tempRef  :: TempRef
+newtype IORef a = IORef { unIORef :: IORef.IORef a } deriving Eq
+newIORef v = IORef <$> IORef.newIORef v
+readIORef (IORef ref) = IORef.readIORef ref
+writeIORef (IORef ref) v = IORef.writeIORef ref v
+
+instance Eq1 IORef where
+  -- NOTE(DarinM223): uses unsafeCoerce here because
+  -- Eq for IORef only checks for pointer equality
+  -- so you can compare IORef a and IORef b even though
+  -- they are different types.
+  liftEq _ f1 f2 = f1 == unsafeCoerce f2
+
+type family Ref (m :: * -> *) :: * -> *
+type instance Ref IO = IORef
+
+type Parser m = ParsecT Void String m
+type ParseErr = ParseErrorBundle String Void
+type ParserContext m = ( ?symbolM :: SymbolM m
+                       , ?refM    :: RefM (Ref m) m
+                       , ?tempRef :: TempRef (Ref m)
+                       )
+
+data ParserContextData m = ParserContextData
+  { symbolM :: SymbolM m
+  , refM    :: RefM (Ref m) m
+  , tempRef :: TempRef (Ref m)
   }
 
-mkConfig :: IO Config
-mkConfig = Config <$> mkSymbolRef <*> mkSymbolTable <*> mkTempRef
+contextDataIO :: IO (ParserContextData IO)
+contextDataIO = do
+  symbolM <- liftIO $ mkSymbolM <$> mkSymbolRef <*> mkSymbolTable
+  tempRef <- liftIO $ mkTempRef refM
+  return $ ParserContextData symbolM refM tempRef
+ where
+  refM = RefM { newRef = newIORef, readRef = readIORef, writeRef = writeIORef }
 
-type Parser = ParsecT Void String (ReaderT Config IO)
-type ParseErr = ParseErrorBundle String Void
+withContextData :: ParserContextData m -> (ParserContext m => m a) -> m a
+withContextData c f =
+  let { ?symbolM = symbolM c; ?refM = refM c; ?tempRef = tempRef c } in f
 
-runMyParserT :: Parser a
+runMyParserT :: ParserContext IO
+             => (ParserContext IO => Parser IO a)
              -> String
              -> IO (Either ParseErr a)
-runMyParserT m s = do
-  config <- mkConfig
-  flip runReaderT config $ runParserT m "" s
+runMyParserT m s = runParserT m "" s
 
-sc :: Parser ()
+runMyParserT' :: (ParserContext IO => Parser IO a)
+              -> String
+              -> IO (Either ParseErr a)
+runMyParserT' m s = runParserT m' "" s
+ where
+  refM = RefM { newRef = newIORef, readRef = readIORef, writeRef = writeIORef }
+  m' = do
+    symbolM <- liftIO $ mkSymbolM <$> mkSymbolRef <*> mkSymbolTable
+    tempRef <- liftIO $ mkTempRef refM
+    let { ?symbolM = symbolM; ?refM = refM; ?tempRef = tempRef } in m
+
+sc :: Parser m ()
 sc = L.space (space1 <|> void tab) empty blockCmnt
  where blockCmnt = L.skipBlockCommentNested "/*" "*/"
 
-lexeme :: Parser a -> Parser a
+lexeme :: Parser m a -> Parser m a
 lexeme = L.lexeme sc
 
-symbol :: String -> Parser String
+symbol :: String -> Parser m String
 symbol = L.symbol sc
 
 rws :: [String]
 rws = [ "while", "for", "to", "break", "let", "in", "end", "function", "var"
       , "type", "array", "if", "then", "else", "do", "of", "nil" ]
 
-rword :: String -> Parser ()
+rword :: String -> Parser m ()
 rword w = (lexeme . try) (string w *> notFollowedBy alphaNumChar)
 
-identifier :: Parser String
+identifier :: Parser m String
 identifier = (lexeme . try) (letters >>= check)
  where
   letters = (:) <$> letterChar <*> many (alphaNumChar <|> char '_')
@@ -56,17 +102,17 @@ identifier = (lexeme . try) (letters >>= check)
     | s `elem` rws = fail $ "keyword " ++ show s ++ " cannot be an identifier"
     | otherwise    = return s
 
-eol' :: Parser ()
+eol' :: Parser m ()
 eol' = void (string "\r\n")
    <|> void (string "\n\r")
    <|> void (char '\r')
    <|> void (char '\n')
    <?> "end of line"
 
-integer :: Parser Int
+integer :: Parser m Int
 integer = L.decimal
 
-string'' :: Parser String
+string'' :: Parser m String
 string'' = char '"' *> many character <* char '"'
  where
   character = escape <|> satisfy (/= '\"')
@@ -91,5 +137,5 @@ singleEscChars = "nt\\\""
 escapeLookupTable :: [(Char, Char)]
 escapeLookupTable = [('n', '\n'), ('t', '\t'), ('\\', '\\'), ('\"', '\"')]
 
-whileParser :: Parser [String]
+whileParser :: Parser m [String]
 whileParser = sc *> sepBy identifier (sc *> char ',' *> sc) <* eof

--- a/src/Chap2/Ref.hs
+++ b/src/Chap2/Ref.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE RankNTypes #-}
+module Chap2.Ref where
+
+import Data.Functor.Classes (Eq1 (liftEq))
+import Unsafe.Coerce (unsafeCoerce)
+
+import qualified Data.IORef as IORef
+
+newtype IORef a = IORef { unIORef :: IORef.IORef a } deriving Eq
+newIORef v = IORef <$> IORef.newIORef v
+readIORef (IORef ref) = IORef.readIORef ref
+writeIORef (IORef ref) v = IORef.writeIORef ref v
+
+instance Eq1 IORef where
+  -- NOTE(DarinM223): uses unsafeCoerce here because
+  -- Eq for IORef only checks for pointer equality
+  -- so you can compare IORef a and IORef b even though
+  -- they are different types.
+  liftEq _ f1 f2 = f1 == unsafeCoerce f2
+
+type family Ref (m :: * -> *) :: * -> *
+type instance Ref IO = IORef
+
+data RefM ref m = RefM
+  { newRef   :: forall a. a -> m (ref a)
+  , readRef  :: forall a. ref a -> m a
+  , writeRef :: forall a. ref a -> a -> m ()
+  }

--- a/src/Chap3/AST.hs
+++ b/src/Chap3/AST.hs
@@ -3,13 +3,8 @@
 {-# LANGUAGE RankNTypes #-}
 module Chap3.AST where
 
+import Chap2.Ref
 import Chap5.Symbol
-
-data RefM ref m = RefM
-  { newRef   :: forall a. a -> m (ref a)
-  , readRef  :: forall a. ref a -> m a
-  , writeRef :: forall a. ref a -> a -> m ()
-  }
 
 newtype Escape ref = Escape { unEscape :: ref Bool }
 instance Show (Escape ref) where

--- a/src/Chap3/Parser.hs
+++ b/src/Chap3/Parser.hs
@@ -4,6 +4,7 @@
 module Chap3.Parser where
 
 import Chap2.Lexer
+import Chap2.Ref
 import Chap3.AST
 import Chap5.Symbol
 import Control.Monad.Combinators.Expr

--- a/src/Chap3/Parser.hs
+++ b/src/Chap3/Parser.hs
@@ -28,18 +28,18 @@ ty = getSourcePos >>= \pos
 
 tyfield :: Monad m => ParserContext m => Parser m (Field (Ref m))
 tyfield = Field
-  <$> getSourcePos
-  <*> ident
-  <*> (symbol ":" *> ident)
-  <*> lift mkEscape
+      <$> getSourcePos
+      <*> ident
+      <*> (symbol ":" *> ident)
+      <*> lift mkEscape
 
 vardec :: Monad m => ParserContext m => Parser m (VarDec' (Ref m))
 vardec = VarDec'
-  <$> getSourcePos
-  <*> (rword "var" *> ident)
-  <*> optional (try annot)
-  <*> (symbol ":=" *> expr)
-  <*> lift mkEscape
+     <$> getSourcePos
+     <*> (rword "var" *> ident)
+     <*> optional (try annot)
+     <*> (symbol ":=" *> expr)
+     <*> lift mkEscape
 
 fundec :: Monad m => ParserContext m => Parser m (FunDec (Ref m))
 fundec = FunDec

--- a/src/Chap5/Semant.hs
+++ b/src/Chap5/Semant.hs
@@ -15,15 +15,13 @@ import Control.Monad (forM_, void, when)
 import Control.Monad.Catch
 import Control.Monad.Reader
 import Chap2.Lexer
-  ( IORef
-  , Parser
+  ( Parser
   , ParserContext
-  , Ref
   , contextDataIO
   , runMyParserT
   , withContextData
   )
-import Chap3.AST (RefM (..))
+import Chap2.Ref (IORef, Ref, RefM (..))
 import Chap3.Parser (parseExpr)
 import Chap5.Symbol
 import Chap5.Table

--- a/src/Chap5/Semant.hs
+++ b/src/Chap5/Semant.hs
@@ -17,7 +17,7 @@ import Control.Monad.Reader
 import Chap2.Lexer
   ( Parser
   , ParserContext
-  , contextDataIO
+  , mkContextData
   , runMyParserT
   , withContextData
   )
@@ -382,7 +382,7 @@ runExp tenv venv exp = do
   transExp exp
 
 testTy :: String -> IO (ExpTy IORef)
-testTy text = contextDataIO >>= \d -> withContextData d $ do
+testTy text = mkContextData >>= \d -> withContextData d $ do
   let ?tempM = mkTempM ?refM ?symbolM ?tempRef
   let ?transM = mkTranslateM ?tempM (Mips.mkFrameM ?tempM)
   (tenv, venv) <- mkEnvs ?symbolM ?transM
@@ -391,7 +391,7 @@ testTy text = contextDataIO >>= \d -> withContextData d $ do
     Right exp -> runExp tenv venv exp
 
 testTySyms :: String -> IO (HM.HashMap String Int, (ExpTy IORef))
-testTySyms text = contextDataIO >>= \d -> withContextData d $ do
+testTySyms text = mkContextData >>= \d -> withContextData d $ do
   let ?tempM = mkTempM ?refM ?symbolM ?tempRef
   let ?transM = mkTranslateM ?tempM (Mips.mkFrameM ?tempM)
   (tenv, venv) <- mkEnvs ?symbolM ?transM

--- a/src/Chap5/Semant.hs
+++ b/src/Chap5/Semant.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TupleSections #-}
 module Chap5.Semant
   ( ExpTy (..)
@@ -10,26 +12,34 @@ module Chap5.Semant
   ) where
 
 import Control.Monad (forM_, void, when)
-import Control.Monad.IO.Class
 import Control.Monad.Catch
 import Control.Monad.Reader
-import Chap2.Lexer (Config (..), mkConfig)
+import Chap2.Lexer
+  ( IORef
+  , Parser
+  , ParserContext
+  , Ref
+  , contextDataIO
+  , runMyParserT
+  , withContextData
+  )
+import Chap3.AST (RefM (..))
 import Chap3.Parser (parseExpr)
 import Chap5.Symbol
 import Chap5.Table
-import Chap6.Temp (mkTempM, TempM (TempM, namedLabel))
+import Chap6.Temp (mkTempM, TempM (namedLabel))
 import Chap6.Translate
-import Data.IORef
+import Data.Functor.Classes (Eq1)
 import Data.Maybe (fromMaybe)
 import Data.Foldable (foldlM, foldl')
-import Text.Megaparsec (runParserT)
 import qualified Chap3.AST as AST
 import qualified Chap6.MipsFrame as Mips
 import qualified Data.IntMap as IM
 import qualified Data.IntSet as IS
 import qualified Data.HashMap.Strict as HM
 
-data ExpTy = ExpTy Exp Ty deriving (Show, Eq)
+data ExpTy r = ExpTy Exp (Ty r) deriving (Show, Eq)
+
 data OpType = Arithmetic -- ^ Operation over two integers
             | Comparison -- ^ Operation over integers or strings
             | Equality   -- ^ Operations over any two equal types
@@ -38,20 +48,20 @@ data OpType = Arithmetic -- ^ Operation over two integers
 data Err = Err Pos String deriving (Show)
 instance Exception Err
 
-data Context frame access m = Context
-  { symbolM :: SymbolM m
-  , transM  :: TransM frame access m
-  , gLevel  :: Level frame
-  , gTenv   :: TEnv
-  , gVenv   :: VEnv frame access
-  , gBreak  :: Bool
-  }
+type Context frame access m
+  = ( ?symbolM :: SymbolM m
+    , ?transM  :: TransM frame access m
+    , ?refM    :: RefM (Ref m) m
+    , ?gLevel  :: Level frame
+    , ?gTenv   :: TEnv (Ref m)
+    , ?gVenv   :: VEnv (Ref m) frame access
+    , ?gBreak  :: Bool )
 
-type SemantT frame access m a = ReaderT (Context frame access m) m a
+type Semant f a m = (MonadThrow m, Eq1 (Ref m), Context f a m)
 
-transVar :: (MonadIO m, MonadThrow m) => AST.Var -> SemantT f a m ExpTy
-transVar var = ask >>= \Context{..} -> case var of
-  AST.SimpleVar id pos -> case look id gVenv of
+transVar :: Semant f a m => AST.Var (Ref m) -> m (ExpTy (Ref m))
+transVar = \case
+  AST.SimpleVar id pos -> case look id ?gVenv of
     Just (VarEntry _ ty) -> ExpTy EUnit <$> actualTy ty
     _ -> throwM $ Err pos $ "undefined variable: " ++ fromSymbol id
   AST.FieldVar var' id pos -> do
@@ -70,13 +80,15 @@ transVar var = ask >>= \Context{..} -> case var of
       _           -> throwM $ Err pos "lvalue not an array type"
 
 -- | Trace through TName types to their underlying definitions.
-actualTy :: MonadIO m => Ty -> m Ty
-actualTy ty@(TName _ (TRef ref)) = liftIO (readIORef ref) >>= \case
+actualTy :: Monad m => (?refM :: RefM r m) => Ty r -> m (Ty r)
+actualTy ty@(TName _ (TRef ref)) = readRef ?refM ref >>= \case
   Just ty -> actualTy ty
   Nothing -> return ty
 actualTy ty = return ty
 
-checkTy :: (MonadIO m, MonadThrow m) => Pos -> Ty -> Ty -> m ()
+checkTy :: (MonadThrow m, Eq1 r)
+        => (?refM :: RefM r m)
+        => Pos -> Ty r -> Ty r -> m ()
 checkTy pos ty ty' = do
   cty <- actualTy ty
   cty' <- actualTy ty'
@@ -84,14 +96,14 @@ checkTy pos ty ty' = do
     throwM $ Err pos $ "type mismatch: expected: "
                     ++ show ty ++ " got: " ++ show ty'
 
-checkDup :: (MonadIO m, MonadThrow m) => [(Symbol, Pos)] -> m ()
+checkDup :: MonadThrow m => [(Symbol, Pos)] -> m ()
 checkDup = void . foldlM go IS.empty
  where
   go set (Symbol (name, id), pos)
     | IS.member id set = throwM $ Err pos $ "Duplicate symbol: " ++ name
     | otherwise        = return $ IS.insert id set
 
-lookTy :: MonadThrow m => Pos -> Symbol -> TEnv -> m Ty
+lookTy :: MonadThrow m => Pos -> Symbol -> TEnv r -> m (Ty r)
 lookTy pos tySym tenv = case look tySym tenv of
   Just ty -> return ty
   _       -> throwM $ Err pos $ "type " ++ show tySym ++ " not found"
@@ -111,7 +123,7 @@ opTypeFromOp = \case
   AST.GtOp     -> Comparison
   AST.GeOp     -> Comparison
 
-checkOpType :: OpType -> Ty -> Bool
+checkOpType :: Eq1 r => OpType -> Ty r -> Bool
 checkOpType Arithmetic ty = ty == TInt
 checkOpType Comparison ty = ty == TInt || ty == TString
 checkOpType Equality ty   = case ty of
@@ -122,14 +134,14 @@ checkOpType Equality ty   = case ty of
   TNil        -> True
   _           -> False
 
-transExp :: (MonadIO m, MonadThrow m) => AST.Exp -> SemantT f a m ExpTy
-transExp exp = ask >>= \Context{symbolM = SymbolM{..}, ..} -> case exp of
+transExp :: Semant f a m => AST.Exp (Ref m) -> m (ExpTy (Ref m))
+transExp = \case
   AST.NilExp        -> return $ ExpTy EUnit TNil
   AST.StringExp _ _ -> return $ ExpTy EUnit TString
   AST.IntExp _      -> return $ ExpTy EUnit TInt
   AST.VarExp var    -> transVar var
 
-  AST.BreakExp pos -> if gBreak
+  AST.BreakExp pos -> if ?gBreak
     then return $ ExpTy EUnit TUnit
     else throwM $ Err pos "Break statement not inside enclosing loop"
 
@@ -149,13 +161,13 @@ transExp exp = ask >>= \Context{symbolM = SymbolM{..}, ..} -> case exp of
 
   AST.WhileExp (AST.WhileExp' pos test body) -> do
     ExpTy _ testTy <- transExp test
-    ExpTy _ bodyTy <- local (\c -> c { gBreak = True }) (transExp body)
+    ExpTy _ bodyTy <- let ?gBreak = True in transExp body
     checkTy pos TInt testTy
     checkTy pos TUnit bodyTy
     return $ ExpTy EUnit bodyTy
 
   AST.ForExp (AST.ForExp' pos varSym escRef lo hi body) -> do
-    limitSym <- lift $ toSymbol "limit"
+    limitSym <- toSymbol ?symbolM "limit"
     let ivar     = AST.SimpleVar varSym pos
         limitvar = AST.SimpleVar limitSym pos
     limitEscRef <- AST.mkEscape
@@ -172,7 +184,7 @@ transExp exp = ask >>= \Context{symbolM = SymbolM{..}, ..} -> case exp of
     transExp $ AST.LetExp $ AST.LetExp' pos decs loop
 
   AST.RecordExp (AST.RecordExp' pos tySym fields) -> do
-    ty <- lookTy pos tySym gTenv >>= actualTy
+    ty <- lookTy pos tySym ?gTenv >>= actualTy
     case ty of
       TRecord fieldTys _ -> do
         fieldTys' <- traverse trField fields
@@ -181,7 +193,7 @@ transExp exp = ask >>= \Context{symbolM = SymbolM{..}, ..} -> case exp of
       _ -> throwM $ Err pos $ "type " ++ show tySym ++ " is not a record"
 
   AST.ArrayExp (AST.ArrayExp' pos tySym size init) -> do
-    arrayTy <- lookTy pos tySym gTenv >>= actualTy
+    arrayTy <- lookTy pos tySym ?gTenv >>= actualTy
     case arrayTy of
       TArray ty _ -> do
         ExpTy _ sizeTy <- transExp size
@@ -194,7 +206,7 @@ transExp exp = ask >>= \Context{symbolM = SymbolM{..}, ..} -> case exp of
   AST.SeqExp exps ->
     foldlM (\_ (_, exp) -> transExp exp) (ExpTy EUnit TNil) exps
 
-  AST.CallExp (AST.CallExp' pos fnSym args) -> case look fnSym gVenv of
+  AST.CallExp (AST.CallExp' pos fnSym args) -> case look fnSym ?gVenv of
     Just (FunEntry _ _ tys rt) -> do
       tys' <- fmap (\(ExpTy _ ty) -> ty) <$> traverse transExp args
       if tys == tys'
@@ -205,10 +217,10 @@ transExp exp = ask >>= \Context{symbolM = SymbolM{..}, ..} -> case exp of
 
   AST.LetExp (AST.LetExp' _ decs body) -> do
     (tenv', venv') <- foldlM
-      (\(!tenv, !venv) dec -> local (\c -> c { gTenv = tenv, gVenv = venv })
-                            $ transDec dec)
-      (gTenv, gVenv) decs
-    local (\c -> c { gTenv = tenv', gVenv = venv' }) $ transExp body
+      (\(!tenv, !venv) dec -> let { ?gTenv = tenv; ?gVenv = venv }
+                              in transDec dec)
+      (?gTenv, ?gVenv) decs
+    let { ?gTenv = tenv'; ?gVenv = venv' } in transExp body
 
   AST.OpExp left op right pos -> do
     ExpTy _ tyleft <- transExp left
@@ -222,10 +234,10 @@ transExp exp = ask >>= \Context{symbolM = SymbolM{..}, ..} -> case exp of
  where
   trField (pos, sym, exp) = (\(ExpTy _ ty) -> (pos, sym, ty)) <$> transExp exp
 
-matchTys :: (MonadIO m, MonadThrow m)
+matchTys :: Semant f a m
          => Pos
-         -> [(Symbol, Ty)]
-         -> [(Pos, Symbol, Ty)]
+         -> [(Symbol, Ty (Ref m))]
+         -> [(Pos, Symbol, Ty (Ref m))]
          -> m ()
 matchTys pos l1 l2
   | length l1 /= length l2 = throwM $ Err pos "Different parameter sizes"
@@ -240,22 +252,23 @@ matchTys pos l1 l2
   buildMap = foldl' append IM.empty
   append map (sym, ty) = IM.insert (symbolValue sym) ty map
 
-transDec :: (MonadIO m, MonadThrow m)
-         => AST.Dec -> SemantT frame access m (TEnv, VEnv frame access)
-transDec dec = ask >>= \Context{transM = TranslateM{..}, ..} -> case dec of
+transDec :: Semant frame access m
+         => AST.Dec (Ref m)
+         -> m (TEnv (Ref m), VEnv (Ref m) frame access)
+transDec = \case
   AST.VarDec (AST.VarDec' _ name Nothing init escapeRef) -> do
     ExpTy _ ty <- transExp init
     escape <- AST.readEscape escapeRef
-    access <- lift $ allocLocal gLevel escape
-    return (gTenv, enter name (VarEntry access ty) gVenv)
+    access <- allocLocal ?transM ?gLevel escape
+    return (?gTenv, enter name (VarEntry access ty) ?gVenv)
 
   AST.VarDec (AST.VarDec' pos name (Just (pos', tySym)) init escapeRef) -> do
-    ty <- lookTy pos' tySym gTenv
+    ty <- lookTy pos' tySym ?gTenv
     ExpTy _ ty' <- transExp init
     checkTy pos ty ty'
     escape <- AST.readEscape escapeRef
-    access <- lift $ allocLocal gLevel escape
-    return (gTenv, enter name (VarEntry access ty) gVenv)
+    access <- allocLocal ?transM ?gLevel escape
+    return (?gTenv, enter name (VarEntry access ty) ?gVenv)
 
   AST.TypeDec decs -> do
     checkDup $ fmap (\(AST.TypeDec' pos name _) -> (name, pos)) decs
@@ -271,7 +284,7 @@ transDec dec = ask >>= \Context{transM = TranslateM{..}, ..} -> case dec of
     tenv' <- foldlM
       (\env (AST.TypeDec' _ name _) ->
         enter name <$> (TName <$> pure name <*> mkTRef) <*> pure env)
-      gTenv
+      ?gTenv
       decs
 
     -- Second pass: if left side symbol is a TName, then translate
@@ -290,7 +303,7 @@ transDec dec = ask >>= \Context{transM = TranslateM{..}, ..} -> case dec of
 
     -- Third pass: check declarations for cycles.
     mapM_ (\(AST.TypeDec' pos name _) -> checkCycles pos name tenv') decs
-    return (tenv', gVenv)
+    return (tenv', ?gVenv)
 
   AST.FunctionDec decs -> do
     checkDup $ fmap (\(AST.FunDec pos name _ _ _) -> (name, pos)) decs
@@ -299,9 +312,9 @@ transDec dec = ask >>= \Context{transM = TranslateM{..}, ..} -> case dec of
     venv' <- foldlM
       (\env (AST.FunDec _ name params rt _)
         ->  enter name
-        <$> lift (funHeader newLevel gTenv name gLevel params rt)
+        <$> funHeader (newLevel ?transM) ?gTenv name ?gLevel params rt
         <*> pure env)
-      gVenv
+      ?gVenv
       decs
 
     -- Second pass: for each declaration, insert the parameter
@@ -314,15 +327,15 @@ transDec dec = ask >>= \Context{transM = TranslateM{..}, ..} -> case dec of
       venv'' <- foldlM
         (\env (AST.Field _ name ty _, access)
           ->  enter name
-          <$> (VarEntry access <$> lookTy pos ty gTenv)
+          <$> (VarEntry access <$> lookTy pos ty ?gTenv)
           <*> pure env)
         venv'
-        (zip params (levelFormals newlevel))
-      rty <- maybe (pure TUnit) (\(_, ty) -> lookTy pos ty gTenv) rt
-      ExpTy _ ty <- local (\c -> c { gLevel = newlevel, gVenv = venv'' })
-                  $ transExp body
+        (zip params (levelFormals ?transM newlevel))
+      rty <- maybe (pure TUnit) (\(_, ty) -> lookTy pos ty ?gTenv) rt
+      ExpTy _ ty <- let { ?gLevel = newlevel; ?gVenv = venv'' }
+                    in transExp body
       checkTy pos rty ty
-    return (gTenv, venv')
+    return (?gTenv, venv')
  where
   checkCycles pos name tenv = go [] name
    where
@@ -343,7 +356,7 @@ transDec dec = ask >>= \Context{transM = TranslateM{..}, ..} -> case dec of
       <*> traverse (\(AST.Field pos _ ty _) -> lookTy pos ty tenv) fields
       <*> maybe (pure TUnit) (\(pos, ty) -> lookTy pos ty tenv) rt
 
-transTy :: (MonadIO m, MonadThrow m) => AST.Ty -> TEnv -> m Ty
+transTy :: Semant f a m => AST.Ty (Ref m) -> TEnv (Ref m) -> m (Ty (Ref m))
 transTy (AST.NameTy sym pos) tenv  = lookTy pos sym tenv
 transTy (AST.RecordTy fields) tenv = do
   checkDup $ fmap (\(AST.Field pos name _ _) -> (name, pos)) fields
@@ -353,49 +366,44 @@ transTy (AST.RecordTy fields) tenv = do
   trField tenv (AST.Field pos name tySym _) = (name,) <$> lookTy pos tySym tenv
 transTy (AST.ArrayTy sym pos) tenv = TArray <$> lookTy pos sym tenv <*> mkUnique
 
-runExp :: (MonadIO m, MonadThrow m)
-       => SymbolM m
-       -> TempM m
-       -> TransM Mips.Frame Mips.Access m
-       -> TEnv
-       -> VEnv Mips.Frame Mips.Access
-       -> AST.Exp
-       -> m ExpTy
-runExp symbolM TempM{..} transM@TranslateM{..} tenv venv exp = do
-  mainName <- namedLabel "main"
-  mainLevel <- newLevel (Init Outermost mainName [])
-  let ctx = Context { symbolM = symbolM
-                    , transM  = transM
-                    , gLevel = mainLevel
-                    , gTenv  = tenv
-                    , gVenv  = venv
-                    , gBreak = False
-                    }
-  runReaderT (transExp exp) ctx
+runExp :: (MonadThrow m, Eq1 (Ref m))
+       => ( ?refM    :: RefM (Ref m) m
+          , ?symbolM :: SymbolM m
+          , ?tempM   :: TempM m
+          , ?transM  :: TransM Mips.Frame Mips.Access m
+          )
+       => TEnv (Ref m)
+       -> VEnv (Ref m) Mips.Frame Mips.Access
+       -> AST.Exp (Ref m)
+       -> m (ExpTy (Ref m))
+runExp tenv venv exp = do
+  mainName <- namedLabel ?tempM "main"
+  mainLevel <- newLevel ?transM (Init Outermost mainName [])
+  let ?gLevel = mainLevel
+      ?gTenv  = tenv
+      ?gVenv  = venv
+      ?gBreak = False
+  transExp exp
 
-testTy :: String -> IO ExpTy
-testTy text = do
-  config <- mkConfig
-  let symbolM = mkSymbolM (_symRef config) (_symTable config)
-      tempM   = mkTempM symbolM (_tempRef config)
-      transM  = mkTranslateM tempM (Mips.mkFrameM tempM)
-  (tenv, venv) <- mkEnvs symbolM transM
-  runReaderT (runParserT parseExpr "" text) config >>= \case
+testTy :: String -> IO (ExpTy IORef)
+testTy text = contextDataIO >>= \d -> withContextData d $ do
+  let ?tempM = mkTempM ?refM ?symbolM ?tempRef
+  let ?transM = mkTranslateM ?tempM (Mips.mkFrameM ?tempM)
+  (tenv, venv) <- mkEnvs ?symbolM ?transM
+  runMyParserT parseExpr text >>= \case
     Left err  -> throwM err
-    Right exp -> runExp symbolM tempM transM tenv venv exp
+    Right exp -> runExp tenv venv exp
 
-testTySyms :: String -> IO (HM.HashMap String Int, ExpTy)
-testTySyms text = do
-  config <- mkConfig
-  let symbolM = mkSymbolM (_symRef config) (_symTable config)
-      tempM   = mkTempM symbolM (_tempRef config)
-      transM  = mkTranslateM tempM (Mips.mkFrameM tempM)
-  (tenv, venv) <- mkEnvs symbolM transM
-  runReaderT (runParserT (parse config) "" text) config >>= \case
+testTySyms :: String -> IO (HM.HashMap String Int, (ExpTy IORef))
+testTySyms text = contextDataIO >>= \d -> withContextData d $ do
+  let ?tempM = mkTempM ?refM ?symbolM ?tempRef
+  let ?transM = mkTranslateM ?tempM (Mips.mkFrameM ?tempM)
+  (tenv, venv) <- mkEnvs ?symbolM ?transM
+  runMyParserT parse text >>= \case
     Left err             -> throwM err
-    Right (exp, symbols) -> (symbols ,)
-                        <$> runExp symbolM tempM transM tenv venv exp
+    Right (exp, symbols) -> (symbols ,) <$> runExp tenv venv exp
  where
-  parse config = (,)
-    <$> parseExpr
-    <*> getSymbols (mkSymbolM (_symRef config) (_symTable config))
+  parse :: Monad m
+        => ParserContext m
+        => Parser m (AST.Exp (Ref m), HM.HashMap String Int)
+  parse = (,) <$> parseExpr <*> lift (getSymbols ?symbolM)

--- a/src/Chap5/Semant.hs
+++ b/src/Chap5/Semant.hs
@@ -55,7 +55,8 @@ type Context frame access m
     , ?gLevel  :: Level frame
     , ?gTenv   :: TEnv (Ref m)
     , ?gVenv   :: VEnv (Ref m) frame access
-    , ?gBreak  :: Bool )
+    , ?gBreak  :: Bool
+    )
 
 type Semant f a m = (MonadThrow m, Eq1 (Ref m), Context f a m)
 

--- a/src/Chap5/Symbol.hs
+++ b/src/Chap5/Symbol.hs
@@ -14,8 +14,8 @@ data SymbolTableM k v m = SymbolTableM
   , tableToList :: m [(k, v)]
   }
 
-symbolTableMIO :: IO (SymbolTableM String Int IO)
-symbolTableMIO = do
+mkSymbolTableM :: IO (SymbolTableM String Int IO)
+mkSymbolTableM = do
   table <- H.new :: IO (H.BasicHashTable k v)
   return SymbolTableM
     { insertTable = H.insert table

--- a/src/Chap5/Symbol.hs
+++ b/src/Chap5/Symbol.hs
@@ -1,50 +1,61 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
 module Chap5.Symbol where
 
-import Control.Monad.Reader
-import Data.IORef
+import Chap2.Ref
 import Text.Megaparsec (SourcePos)
 
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashTable.IO as H
 
-type SymbolTable = H.BasicHashTable String Int
+data SymbolTableM k v m = SymbolTableM
+  { insertTable :: k -> v -> m ()
+  , lookupTable :: k -> m (Maybe v)
+  , tableToList :: m [(k, v)]
+  }
 
-mkSymbolTable :: IO SymbolTable
-mkSymbolTable = H.new
+symbolTableMIO :: IO (SymbolTableM String Int IO)
+symbolTableMIO = do
+  table <- H.new :: IO (H.BasicHashTable k v)
+  return SymbolTableM
+    { insertTable = H.insert table
+    , lookupTable = H.lookup table
+    , tableToList = H.toList table
+    }
 
 type Pos = SourcePos
 newtype Symbol = Symbol { unSymbol :: (String, Int) } deriving (Show)
 instance Eq Symbol where
   Symbol (_, i1) == Symbol (_, i2) = i1 == i2
 
-newtype SymbolRef = SymbolRef { unSymbolRef :: IORef Int }
+newtype SymbolRef r = SymbolRef { unSymbolRef :: r Int }
 
-mkSymbolRef :: IO SymbolRef
-mkSymbolRef = SymbolRef <$> newIORef 0
+mkSymbolRef :: Functor f => RefM r f -> f (SymbolRef r)
+mkSymbolRef refM = SymbolRef <$> newRef refM 0
 
 data SymbolM m = SymbolM
   { toSymbol   :: String -> m Symbol
   , getSymbols :: m (HM.HashMap String Int)
   }
 
-mkSymbolM :: MonadIO m => SymbolRef -> SymbolTable -> SymbolM m
-mkSymbolM ref table = SymbolM
-  { toSymbol   = toSymbol' ref table
-  , getSymbols = getSymbols' table
+mkSymbolM :: Monad m
+          => RefM (Ref m) m
+          -> SymbolTableM String Int m
+          -> SymbolRef (Ref m)
+          -> SymbolM m
+mkSymbolM RefM{..} SymbolTableM{..} (SymbolRef ref) = SymbolM
+  { toSymbol   = toSymbol'
+  , getSymbols = getSymbols'
   }
-
-toSymbol' :: MonadIO m => SymbolRef -> SymbolTable -> String -> m Symbol
-toSymbol' (SymbolRef ref) table str = liftIO (H.lookup table str) >>= \case
-  Just sym -> return $ Symbol (str, sym)
-  Nothing  -> liftIO $ do
-    sym <- readIORef ref
-    H.insert table str sym
-    writeIORef ref (sym + 1)
-    return $ Symbol (str, sym)
-
-getSymbols' :: MonadIO m => SymbolTable -> m (HM.HashMap String Int)
-getSymbols' table = HM.fromList <$> liftIO (H.toList table)
+ where
+  toSymbol' str = lookupTable str >>= \case
+    Just sym -> return $ Symbol (str, sym)
+    Nothing  -> do
+      sym <- readRef ref
+      insertTable str sym
+      writeRef ref (sym + 1)
+      return $ Symbol (str, sym)
+  getSymbols' = HM.fromList <$> tableToList
 
 fromSymbol :: Symbol -> String
 fromSymbol = fst . unSymbol

--- a/src/Chap5/Table.hs
+++ b/src/Chap5/Table.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TupleSections #-}
 module Chap5.Table where
 
-import Chap3.AST (RefM (..))
+import Chap2.Ref (RefM (..))
 import Chap5.Symbol
 import Chap6.Translate
 import Data.Functor.Classes (Eq1, eq1)

--- a/src/Chap5/Table.hs
+++ b/src/Chap5/Table.hs
@@ -6,7 +6,7 @@ module Chap5.Table where
 import Chap3.AST (RefM (..))
 import Chap5.Symbol
 import Chap6.Translate
-import Data.Functor.Classes (Eq1 (liftEq))
+import Data.Functor.Classes (Eq1, eq1)
 
 import qualified Data.IntMap as IM
 
@@ -25,7 +25,7 @@ data Unique r = Unique (r ()) | UniqueIgnore
 instance Eq1 r => Eq (Unique r) where
   UniqueIgnore == _          = True
   _ == UniqueIgnore          = True
-  Unique ref1 == Unique ref2 = liftEq (==) ref1 ref2
+  Unique ref1 == Unique ref2 = eq1 ref1 ref2
 instance Show (Unique r) where
   show _ = ""
 
@@ -34,7 +34,7 @@ mkUnique = Unique <$> newRef ?refM ()
 
 newtype TRef r = TRef (r (Maybe (Ty r)))
 instance Eq1 r => Eq (TRef r) where
-  TRef r1 == TRef r2 = liftEq (==) r1 r2
+  TRef r1 == TRef r2 = eq1 r1 r2
 instance Show (TRef r) where
   show _ = ""
 

--- a/src/Chap6/Temp.hs
+++ b/src/Chap6/Temp.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE RecordWildCards #-}
 module Chap6.Temp where
 
-import Chap3.AST
+import Chap2.Ref
 import Chap5.Symbol
 
 newtype Temp = Temp { unTemp :: Int } deriving (Eq, Num)

--- a/src/Chap6/Temp.hs
+++ b/src/Chap6/Temp.hs
@@ -42,8 +42,6 @@ newTemp' RefM{..} (TempRef ref) = do
 
 newLabel' :: Monad m => RefM r m -> SymbolM m -> TempRef r -> m Label
 newLabel' RefM{..} SymbolM{..} (TempRef ref) = do
-  l <- do
-    tempData <- readRef ref
-    writeRef ref tempData { _label = _label tempData + 1 }
-    return $ _label tempData
-  toSymbol $ "L" ++ show l
+  tempData <- readRef ref
+  writeRef ref tempData { _label = _label tempData + 1 }
+  toSymbol $ "L" ++ show (_label tempData)

--- a/src/ST.hs
+++ b/src/ST.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+module ST where
+
+import Chap2.Lexer hiding (mkContextData)
+import Chap2.Ref
+import Chap3.AST (Exp, convertExp)
+import Chap3.Parser (parseExpr)
+import Chap5.Symbol hiding (mkSymbolTableM)
+import Chap6.Temp
+import Control.Monad.ST
+import Data.STRef
+import Text.Megaparsec (runParserT)
+
+import qualified Data.HashTable.Class as H
+import qualified Data.HashTable.ST.Basic as HB
+
+type instance Ref (ST s) = STRef s
+
+mkSymbolTableM :: ST s (SymbolTableM String Int (ST s))
+mkSymbolTableM = do
+  table <- HB.new
+  return SymbolTableM
+    { insertTable = H.insert table
+    , lookupTable = H.lookup table
+    , tableToList = H.toList table
+    }
+
+mkContextData :: ST s (ParserContextData (ST s))
+mkContextData = do
+  symbolM <- mkSymbolM refM <$> mkSymbolTableM <*> mkSymbolRef refM
+  tempRef <- mkTempRef refM
+  return $ ParserContextData symbolM refM tempRef
+ where
+  refM = RefM { newRef = newSTRef, readRef = readSTRef, writeRef = writeSTRef }
+
+newtype BoolValue a = BoolValue Bool deriving (Show, Eq)
+
+convert :: STRef s Bool -> ST s (BoolValue Bool)
+convert ref = BoolValue <$> readSTRef ref
+
+runSTParser :: (ParserContext (ST s) => Parser (ST s) a)
+            -> String
+            -> ST s (Either ParseErr a)
+runSTParser m s = mkContextData >>= \d -> withContextData d $ runParserT m "" s
+
+parse :: String -> Either ParseErr (Exp BoolValue)
+parse s = runST $ runSTParser parseExpr s >>=
+  either (pure . Left) (fmap Right . convertExp convert)

--- a/test/ParserTest.hs
+++ b/test/ParserTest.hs
@@ -19,21 +19,23 @@ tests = testGroup "Parser tests"
   , testCase "Tests empty record dec" (testExp testParseEmptyRecord False)
   ]
 
-testExp :: IO (Either ParseErr Exp) -> Bool -> IO ()
+type ExpIO = Exp (Ref IO)
+
+testExp :: IO (Either ParseErr ExpIO) -> Bool -> IO ()
 testExp m debug = m >>= \case
   Left e    -> assertFailure $ errorBundlePretty e
   Right exp -> if debug then print exp else return ()
 
-testParseCall :: IO (Either ParseErr Exp)
-testParseCall = runMyParserT
+testParseCall :: IO (Either ParseErr ExpIO)
+testParseCall = runMyParserT'
   parseExpr
   "foo(hello.bar, blah[boo], hello.world[bob])"
 
-testParseEmptyRecord :: IO (Either ParseErr Exp)
-testParseEmptyRecord = runMyParserT parseExpr "let type rec = {} in end"
+testParseEmptyRecord :: IO (Either ParseErr ExpIO)
+testParseEmptyRecord = runMyParserT' parseExpr "let type rec = {} in end"
 
-testSample1 :: IO (Either ParseErr Exp)
-testSample1 = runMyParserT parseExpr sample1
+testSample1 :: IO (Either ParseErr ExpIO)
+testSample1 = runMyParserT' parseExpr sample1
  where
   sample1 = T.unpack
     [text|
@@ -67,8 +69,8 @@ testSample1 = runMyParserT parseExpr sample1
       end
     |]
 
-testSample2 :: IO (Either ParseErr Exp)
-testSample2 = runMyParserT parseExpr sample2
+testSample2 :: IO (Either ParseErr ExpIO)
+testSample2 = runMyParserT' parseExpr sample2
  where
   sample2 = T.unpack
     [text|

--- a/test/ParserTest.hs
+++ b/test/ParserTest.hs
@@ -3,6 +3,7 @@
 module ParserTest (tests) where
 
 import Chap2.Lexer
+import Chap2.Ref
 import Chap3.AST
 import Chap3.Parser
 import NeatInterpolation

--- a/test/ParserTest.hs
+++ b/test/ParserTest.hs
@@ -3,122 +3,114 @@
 module ParserTest (tests) where
 
 import Chap2.Lexer
-import Chap2.Ref
 import Chap3.AST
-import Chap3.Parser
+import Control.Monad (when)
 import NeatInterpolation
+import ST
 import Test.Tasty
 import Test.Tasty.HUnit
-import Text.Megaparsec
+import Text.Megaparsec (errorBundlePretty)
 import qualified Data.Text as T
 
 tests :: TestTree
 tests = testGroup "Parser tests"
-  [ testCase "Tests parsing call" (testExp testParseCall False)
-  , testCase "Tests on sample program 1" (testExp testSample1 False)
-  , testCase "Tests on sample program 2" (testExp testSample2 False)
-  , testCase "Tests empty record dec" (testExp testParseEmptyRecord False)
+  [ testCase "Tests parsing call" (testExp False testParseCall)
+  , testCase "Tests on sample program 1" (testExp False testSample1)
+  , testCase "Tests on sample program 2" (testExp False testSample2)
+  , testCase "Tests empty record dec" (testExp False testParseEmptyRecord)
   ]
 
-type ExpIO = Exp (Ref IO)
-
-testExp :: IO (Either ParseErr ExpIO) -> Bool -> IO ()
-testExp m debug = m >>= \case
+testExp :: Bool -> Either ParseErr (Exp BoolValue) -> IO ()
+testExp debug = \case
   Left e    -> assertFailure $ errorBundlePretty e
-  Right exp -> if debug then print exp else return ()
+  Right exp -> when debug $ print exp
 
-testParseCall :: IO (Either ParseErr ExpIO)
-testParseCall = runMyParserT'
-  parseExpr
-  "foo(hello.bar, blah[boo], hello.world[bob])"
+testParseCall :: Either ParseErr (Exp BoolValue)
+testParseCall = parse "foo(hello.bar, blah[boo], hello.world[bob])"
 
-testParseEmptyRecord :: IO (Either ParseErr ExpIO)
-testParseEmptyRecord = runMyParserT' parseExpr "let type rec = {} in end"
+testParseEmptyRecord :: Either ParseErr (Exp BoolValue)
+testParseEmptyRecord = parse "let type rec = {} in end"
 
-testSample1 :: IO (Either ParseErr ExpIO)
-testSample1 = runMyParserT' parseExpr sample1
- where
-  sample1 = T.unpack
-    [text|
-      let
-        var N := 8
+testSample1 :: Either ParseErr (Exp BoolValue)
+testSample1 = parse $ T.unpack
+  [text|
+    let
+      var N := 8
 
-        type intArray = array of int
+      type intArray = array of int
 
-        var row := intArray [ N ] of 0
-        var col := intArray [ N ] of 0
-        var diag1 := intArray [N+N-1] of 0
-        var diag2 := intArray [N+N-1] of 0
+      var row := intArray [ N ] of 0
+      var col := intArray [ N ] of 0
+      var diag1 := intArray [N+N-1] of 0
+      var diag2 := intArray [N+N-1] of 0
 
-        function printboard() =
-          (for i := 0 to N-1
-            do (for j := 0 to N-1
-                 do print(if col[i]=j then " O" else " .");
-               print("\n"));
-            print("\n"))
+      function printboard() =
+        (for i := 0 to N-1
+          do (for j := 0 to N-1
+               do print(if col[i]=j then " O" else " .");
+             print("\n"));
+          print("\n"))
 
-        function try(c:int) =
-          if c=N
-          then printboard()
-          else for r := 0 to N-1
-                do if row[r]=0 & diag1[r+c]=0 & diag2[r+7-c]=0
-                   then (row[r]:=1; diag1[r+c]:=1; diag2[r+7-c]:=1;
-                         col[c]:=r;
-                         try(c+1);
-                         row[r]:=0; diag1[r+c]:=0; diag2[r+7-c]:=0)
-        in try(0)
+      function try(c:int) =
+        if c=N
+        then printboard()
+        else for r := 0 to N-1
+              do if row[r]=0 & diag1[r+c]=0 & diag2[r+7-c]=0
+                 then (row[r]:=1; diag1[r+c]:=1; diag2[r+7-c]:=1;
+                       col[c]:=r;
+                       try(c+1);
+                       row[r]:=0; diag1[r+c]:=0; diag2[r+7-c]:=0)
+      in try(0)
+    end
+  |]
+
+testSample2 :: Either ParseErr (Exp BoolValue)
+testSample2 = parse $ T.unpack
+  [text|
+    let   type any = {any: int}
+          var buffer := getchar()
+
+      function readint(any: any) : int =
+       let var i := 0
+           function isdigit(s : string) : int =
+              ord(buffer)>=ord("0") & ord(buffer)<=ord("9")
+        in while buffer=" " | buffer="\n" do buffer := getchar();
+           any.any := isdigit(buffer);
+           while isdigit(buffer)
+            do (i := i*10+ord(buffer)-ord("0");
+                buffer := getchar());
+           i
       end
-    |]
 
-testSample2 :: IO (Either ParseErr ExpIO)
-testSample2 = runMyParserT' parseExpr sample2
- where
-  sample2 = T.unpack
-    [text|
-      let   type any = {any: int}
-            var buffer := getchar()
+      type list = {first: int, rest: list}
 
-        function readint(any: any) : int =
-         let var i := 0
-             function isdigit(s : string) : int =
-                ord(buffer)>=ord("0") & ord(buffer)<=ord("9")
-          in while buffer=" " | buffer="\n" do buffer := getchar();
-             any.any := isdigit(buffer);
-             while isdigit(buffer)
-              do (i := i*10+ord(buffer)-ord("0");
-                  buffer := getchar());
-             i
-        end
+      function readlist() : list =
+          let var any := any{any=0}
+              var i := readint(any)
+           in if any.any
+               then list{first=i,rest=readlist()}
+               else (buffer := getchar(); nil)
+          end
 
-        type list = {first: int, rest: list}
+      function merge(a: list, b: list) : list =
+        if a=nil then b
+        else if b=nil then a
+        else if a.first < b.first
+            then list{first=a.first,rest=merge(a.rest,b)}
+            else list{first=b.first,rest=merge(a,b.rest)}
 
-        function readlist() : list =
-            let var any := any{any=0}
-                var i := readint(any)
-             in if any.any
-                 then list{first=i,rest=readlist()}
-                 else (buffer := getchar(); nil)
-            end
+      function printint(i: int) =
+       let function f(i:int) = if i>0
+               then (f(i/10); print(chr(i-i/10*10+ord("0"))))
+        in if i<0 then (print("-"); f(-i))
+           else if i>0 then f(i)
+           else print("0")
+       end
 
-        function merge(a: list, b: list) : list =
-          if a=nil then b
-          else if b=nil then a
-          else if a.first < b.first
-              then list{first=a.first,rest=merge(a.rest,b)}
-              else list{first=b.first,rest=merge(a,b.rest)}
+      function printlist(l: list) =
+        if l=nil then print("\n")
+        else (printint(l.first); print(" "); printlist(l.rest))
 
-        function printint(i: int) =
-         let function f(i:int) = if i>0
-                 then (f(i/10); print(chr(i-i/10*10+ord("0"))))
-          in if i<0 then (print("-"); f(-i))
-             else if i>0 then f(i)
-             else print("0")
-         end
-
-        function printlist(l: list) =
-          if l=nil then print("\n")
-          else (printint(l.first); print(" "); printlist(l.rest))
-
-        in printlist(merge(readlist(), readlist()))
-      end
-    |]
+      in printlist(merge(readlist(), readlist()))
+    end
+  |]

--- a/test/TypeCheckTest.hs
+++ b/test/TypeCheckTest.hs
@@ -3,6 +3,7 @@
 module TypeCheckTest (tests) where
 
 import Control.Monad.Catch
+import Chap2.Lexer (Ref)
 import Chap5.Semant
 import Chap5.Symbol
 import Chap5.Table hiding (look)
@@ -10,6 +11,8 @@ import Chap6.Translate
 import Test.Tasty
 import Test.Tasty.HUnit
 import qualified Data.HashMap.Strict as HM
+
+type ExpTyIO = ExpTy (Ref IO)
 
 tests :: TestTree
 tests = testGroup "Type checking tests"
@@ -31,19 +34,19 @@ testExpTy m comp = do
   let result' = eitherToMaybe result
   result' == comp @? "Expected: " ++ show comp ++ "\nActual: " ++ show result
 
-testLet :: IO (Either SomeException ExpTy)
+testLet :: IO (Either SomeException ExpTyIO)
 testLet = try $ testTy "let type a = int\n var a : a := 2 in a end"
 
-testCall :: IO (Either SomeException ExpTy)
+testCall :: IO (Either SomeException ExpTyIO)
 testCall = try $ testTy $ "let function add(a : int, b: int): int = a + b\n"
                        ++ "var a : int := 2\n var b := 3 in add(a, b) end"
 
-testTableVals :: [String] -> [Maybe ExpTy] -> [TestTree]
+testTableVals :: [String] -> [Maybe ExpTyIO] -> [TestTree]
 testTableVals ts es = fmap toTestCase $ zip [1..] $ zip ts es
  where toTestCase (n, (t, e)) = testCase (show n) (testExpTy (try (testTy t)) e)
 
 testTableSyms :: [String]
-              -> [HM.HashMap String Int -> Maybe ExpTy]
+              -> [HM.HashMap String Int -> Maybe ExpTyIO]
               -> [TestTree]
 testTableSyms ts es = fmap toTestCase $ zip [1..] $ zip ts es
  where

--- a/test/TypeCheckTest.hs
+++ b/test/TypeCheckTest.hs
@@ -3,7 +3,7 @@
 module TypeCheckTest (tests) where
 
 import Control.Monad.Catch
-import Chap2.Lexer (Ref)
+import Chap2.Ref (Ref)
 import Chap5.Semant
 import Chap5.Symbol
 import Chap5.Table hiding (look)


### PR DESCRIPTION
Removes `IO` from the `Parser` monad transformer and removes `MonadIO` constraints from `transExp`. Changes data that would normally use `IORef` like `Var`, `Exp`, `Ty`, `ExpTy`, etc to take in an extra type variable `r` that abstracts over the type of reference.